### PR TITLE
layout: use correct link for docs in the header

### DIFF
--- a/documentation/source/_templates/layout.html
+++ b/documentation/source/_templates/layout.html
@@ -58,7 +58,7 @@
         </img>
       </a>
       <nav class="header-nav" id="js-header-nav">
-          <a href="http://documentation.vulcan-proxy.com" class="active"><b>Documentation</b></a>
+          <a href="//www.vulcanproxy.com" class="active"><b>Documentation</b></a>
       </nav>
       <button id="js-show-nav"><i class="icon-reorder"></i></button>
   </div>


### PR DESCRIPTION
The "Documentation" in the layout header linked to
http://documentation.vulcan-proxy.com. The link at which the docs are
currently hosted is www.vulcanproxy.com. Corrected the link and made it
schemaless.
