### PR TITLE
Do not quote 0.0.0.0 in quickstart docs

### DIFF
--- a/documentation/source/quickstart.rst
+++ b/documentation/source/quickstart.rst
@@ -17,7 +17,7 @@ The easiest way to install Vulcand is to pull the trusted build from the hub.doc
   docker pull mailgun/vulcand
 
   # launch vulcand in a container
-  docker run -d -p 8182:8182 -p 8181:8181 mailgun/vulcand /go/bin/vulcand -apiInterface="0.0.0.0" --etcd=http://172.17.42.1:4001
+  docker run -d -p 8182:8182 -p 8181:8181 mailgun/vulcand /go/bin/vulcand -apiInterface=0.0.0.0 --etcd=http://172.17.42.1:4001
 
 You can check if Vulcand is running by checking the logs of the container: 
 


### PR DESCRIPTION
It brakes when used in systemd unit file directly like:

```
ExecStart=/usr/bin/docker run --name vulcand -p 8182:8182 -p 8181:8181 mailgun/vulcand /go/bin/vulcand -apiInterface="0.0.0.0" --etcd=http://172.17.42.1:4001
```

This is because systemd executes the command without bash hance no quote parsing and vulcand raises error:

```
Service exited with error: service start failure: listen tcp: lookup "0.0.0.0": no such host
```
