### PR TITLE
Strip protocol part from url of stylesheets

### DIFF
--- a/documentation/source/_templates/layout.html
+++ b/documentation/source/_templates/layout.html
@@ -2,7 +2,7 @@
 {% if corpsite_hostname == ""  %}
   {% set corpsite_hostname = "www.mailgun.com" %}
 {% endif %}
-{% set css_url = "http://" + corpsite_hostname + "/static/css/main.css" %}
+{% set css_url = "//" + corpsite_hostname + "/static/css/main.css" %}
 {%- block doctype -%}
 <!doctype html>
 <!--[if lt IE 7]> <html class="lt-ie9 lt-ie8 lt-ie7 documentation"> <![endif]-->


### PR DESCRIPTION
To avoid browser warnings about mixed content if main site uses https://.